### PR TITLE
Assume Role を実行するダイアログの実装

### DIFF
--- a/src/main/kotlin/net/millenary/intellij/plugin/onelogin_aws/ui/AwsAssumeRoleWithOneloginDialog.kt
+++ b/src/main/kotlin/net/millenary/intellij/plugin/onelogin_aws/ui/AwsAssumeRoleWithOneloginDialog.kt
@@ -1,0 +1,53 @@
+package net.millenary.intellij.plugin.onelogin_aws.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.layout.Row
+import com.intellij.ui.layout.panel
+import net.millenary.intellij.plugin.onelogin_aws.setting.OneloginAwsAssumeRoleSettings
+import net.millenary.intellij.plugin.onelogin_aws.ui.data.AwsAssumeRoleWithOneloginProperties
+import javax.swing.JComponent
+
+class AwsAssumeRoleWithOneloginDialog(project: Project) : DialogWrapper(project, true) {
+
+  private val projectSettings: OneloginAwsAssumeRoleSettings
+
+  private val properties: AwsAssumeRoleWithOneloginProperties
+
+  init {
+    projectSettings = OneloginAwsAssumeRoleSettings.getInstance(project)
+    properties = AwsAssumeRoleWithOneloginProperties.from(projectSettings)
+
+    title = "AWS Assume Role With OneLogin"
+    setOKButtonText("Next")
+    setSize(480, 200)
+
+    init()
+  }
+
+  override fun createCenterPanel(): JComponent = panel {
+    blockRow {
+      oneloginAccountDetailsRow()
+    }
+  }
+
+  private fun Row.oneloginAccountDetailsRow() =
+    titledRow("OneLogin Account Details") {
+      row {
+        label("Username")
+        textField(properties::username)
+      }
+      row {
+        label("Password")
+        textField(properties::password)
+      }
+      row {
+        label("App ID")
+        textField(properties::appId)
+      }
+      row {
+        label("Instance Sub-domain")
+        textField(properties::instanceSubDomain)
+      }
+    }
+}

--- a/src/main/kotlin/net/millenary/intellij/plugin/onelogin_aws/ui/action/AwsAssumeRoleWithOneloginAction.kt
+++ b/src/main/kotlin/net/millenary/intellij/plugin/onelogin_aws/ui/action/AwsAssumeRoleWithOneloginAction.kt
@@ -1,0 +1,16 @@
+package net.millenary.intellij.plugin.onelogin_aws.ui.action
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import net.millenary.intellij.plugin.onelogin_aws.ui.AwsAssumeRoleWithOneloginDialog
+
+/**
+ * [AwsAssumeRoleWithOneloginDialog] を表示するトリガーアクション
+ */
+class AwsAssumeRoleWithOneloginAction : AnAction() {
+
+  override fun actionPerformed(e: AnActionEvent) {
+    val dialog = AwsAssumeRoleWithOneloginDialog(requireNotNull(e.project))
+    dialog.show()
+  }
+}

--- a/src/main/kotlin/net/millenary/intellij/plugin/onelogin_aws/ui/data/AwsAssumeRoleWithOneloginProperties.kt
+++ b/src/main/kotlin/net/millenary/intellij/plugin/onelogin_aws/ui/data/AwsAssumeRoleWithOneloginProperties.kt
@@ -1,0 +1,22 @@
+package net.millenary.intellij.plugin.onelogin_aws.ui.data
+
+import net.millenary.intellij.plugin.onelogin_aws.setting.OneloginAwsAssumeRoleSettings
+
+data class AwsAssumeRoleWithOneloginProperties(
+
+  var username: String = "",
+
+  var password: String = "",
+
+  var appId: String = "",
+
+  var instanceSubDomain: String = ""
+) {
+
+  companion object {
+
+    fun from(projectSettings: OneloginAwsAssumeRoleSettings) = AwsAssumeRoleWithOneloginProperties(
+      instanceSubDomain = projectSettings.oneloginSdkInstanceSubDomain
+    )
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,4 +13,11 @@
                              instance="net.millenary.intellij.plugin.onelogin_aws.setting.OneloginAwsAssumeRoleConfiguration"
                              dynamic="true"/>
     </extensions>
+    <actions>
+        <action id="AwsAssumeRoleWithOneloginAction"
+                class="net.millenary.intellij.plugin.onelogin_aws.ui.action.AwsAssumeRoleWithOneloginAction"
+                text="AWS Assume Role with OneLogin">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+    </actions>
 </idea-plugin>


### PR DESCRIPTION
## 概要

OneLogin のアカウント情報を入力して、 Assume Role を実行するダイアログを実装する

## チェックリスト

- [x] OneLogin のアカウント情報を入力するダイアログの実装
- [ ] OneLogin の MFA を要求するダイアログの実装
- [ ] AWS アカウントの各ロールをリストから選択するダイアログの実装